### PR TITLE
Preliminary datapackage file for description & validation

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -1,0 +1,593 @@
+{
+    "profile": "tabular-data-package",
+    "resources": [
+        {
+            "path": "data/canonical_story.csv",
+            "profile": "tabular-data-resource",
+            "name": "canonical_story",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "Macomber ID",
+                        "type": "string",
+                        "format": "default",
+                        "constraints": {
+                            "required": true,
+                            "unique": true,
+                            "pattern": "^[1-9]\\d*(-[A-F][1-2]?)?$"
+                        }
+                    },
+                    {
+                        "name": "Macomber Title",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Origin",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Poncelet Number",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Hamburg ID",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "English Translation",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Print Version",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Notes",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Macomber Keywords",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "CSM Number",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Clavis ID",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Translation of Story into English",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Translations; formerly English Translation",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Macomber ID Number",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Macomber ID Letter",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/collection.csv",
+            "profile": "tabular-data-resource",
+            "name": "collection",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "Name",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Collection Abbreviation",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Institution Abbreviation",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Collection Name",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Institution Name",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Country",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "City",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Latitude",
+                        "type": "number",
+                        "format": "default",
+                        "constraints": {
+                            "minimum": -90.0,
+                            "maximum": 90.0
+                        }
+                    },
+                    {
+                        "name": "Longitude",
+                        "type": "number",
+                        "format": "default",
+                        "constraints": {
+                            "minimum": -180.0,
+                            "maximum": 180.0
+                        }
+                    },
+                    {
+                        "name": "Source",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Notes",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/manuscript.csv",
+            "profile": "tabular-data-resource",
+            "name": "manuscript",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "Manuscript Name",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "ID",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Title",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Collection",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Original Collection",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Total Stories",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Total Folios",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Total Pages",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Century",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Date Range Start",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Date Range End",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Date Note",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Provenance",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Link",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Notes",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "vHMML permalink (pending on 04/25/2020)",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Columns per page",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Lines per column",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Characters per line",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Hamburg MS ID",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Latitude",
+                        "type": "number",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Longitude",
+                        "type": "number",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Place Recorded/Purchased",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Title from catalog",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Total Stories according to catalog",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Number of Paintings according to catalog",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Link to catalog",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Catalog has miracles records",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Can be used for sequence (miracles folio range matches with catalog)",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Mss rebound in disorder or there are breaks in the sequence of TM",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/story_instance.csv",
+            "profile": "tabular-data-resource",
+            "name": "story_instance",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "Manuscript",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Canonical Story ID",
+                        "type": "string",
+                        "format": "default",
+                        "constraints": {
+                            "pattern": "^[1-9]\\d*(-[A-F][1-2]?)?$"
+                        }
+                    },
+                    {
+                        "name": "Canonical Story Title",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Folio Start",
+                        "type": "string",
+                        "format": "default",
+                        "constraint": {
+                            "pattern": "^[1-9]+\\d*[rvab]?$"
+                        }
+                    },
+                    {
+                        "name": "Column Start",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Line Start",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Folio End",
+                        "type": "string",
+                        "format": "default",
+                        "constraint": {
+                            "pattern": "^[1-9]+\\d*[rvab]?$"
+                        }
+
+                    },
+                    {
+                        "name": "Column End",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Line End",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Miracle Number",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Number of Paintings",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Incipit",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Canonical Incipit",
+                        "type": "boolean",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Confidence Score",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Exclude from ITool",
+                        "type": "boolean",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Notes",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Best Incipit Tool Match",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Story Incomplete",
+                        "type": "boolean",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Blank TM folios",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Ethiopic Story Number",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Story Variation",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "High Confidence Not IT",
+                        "type": "boolean",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Princeton Catalog Folios",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Princeton Catalog Titles",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Body of story start folio & line",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Macomber Incipit",
+                        "type": "boolean",
+                        "format": "default"
+                    },
+                    {
+                        "name": "(test on whether there are two incipits in the ITool on the same folio)",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Test for whether the incipit is not unique",
+                        "type": "boolean",
+                        "format": "default"
+                    },
+                    {
+                        "name": "New mss (column for sorting)",
+                        "type": "number",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Miracles sequence number",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Folio Start Number",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Folio Start Letter",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Temporary English Translation for TGS 1994, to be moved when ID'd",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Manuscript Date Range Start",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Manuscript Date Range End",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Story Century",
+                        "type": "integer",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Story Latitude",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Story Longitude",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        },
+        {
+            "path": "data/story_origin.csv",
+            "profile": "tabular-data-resource",
+            "name": "story_origin",
+            "format": "csv",
+            "mediatype": "text/csv",
+            "encoding": "utf-8",
+            "schema": {
+                "fields": [
+                    {
+                        "name": "Name",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Region",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Notes",
+                        "type": "string",
+                        "format": "default"
+                    },
+                    {
+                        "name": "Town/Country",
+                        "type": "string",
+                        "format": "default"
+                    }
+                ],
+                "missingValues": [
+                    ""
+                ]
+            }
+        }
+    ]
+}

--- a/datapackage.json
+++ b/datapackage.json
@@ -336,6 +336,20 @@
                 ],
                 "missingValues": [
                     ""
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "Collection",
+                        "reference": {
+                            "resource": "collection",
+                            "fields": "name"
+                        },
+                        "fields": "Original Collection",
+                        "reference": {
+                            "resource": "collection",
+                            "fields": "name"
+                        }
+                    }
                 ]
             }
         },
@@ -551,6 +565,20 @@
                 ],
                 "missingValues": [
                     ""
+                ],
+                "foreignKeys": [
+                    {
+                        "fields": "Manuscript",
+                        "reference": {
+                            "resource": "manuscript",
+                            "fields": "Manuscript Name"
+                        },
+                        "fields": "Canonical Story ID",
+                        "reference": {
+                            "resource": "canonical_story",
+                            "fields": "Macomber ID"
+                        }
+                    }
                 ]
             }
         },


### PR DESCRIPTION
Created a datapackage definition using [datapackage-py](https://github.com/frictionlessdata/datapackage-py) — inferred from the existing csv files and then revised:
- adjusted field definitions (somewhat, likely still needs work for fields not in our schema)
- added constraints to match those applied as validation in google sheets
- added foreign key definitions (these may not be complete)

Can be used with goodtables to validate like this:
`goodtables validate datapackage.json -o validation.txt`
(Recommend sending output to a file because it's still very verbose because of the number of duplicate rows in the story instance sheet).